### PR TITLE
Fix folder structure

### DIFF
--- a/posts/jrtrainpack/index.html
+++ b/posts/jrtrainpack/index.html
@@ -124,14 +124,14 @@
 <h2 id="構成">構成</h2>
 <h3 id="フォルダの構成">フォルダの構成</h3>
 <pre><code>Scenarios
-└── Rock_On    &lt;== Rock_On 制作のアドオンは、ここに入ります。
-    └── Train  &lt;== 車両アドオンは、ここに入ります。
-    │   └── JR &lt;== JR会社および国鉄に所属の車両は、ここに入ります。
-    │       ├── Formation   &lt;== 各車両区ごとのフォルダの中に、 Vehicle.txt 相当のファイルが入っています。
-    │       ├── Plugin      &lt;== Atsプラグインが入っています。
-    │       └── Vehicle     &lt;== 車両形式ごとに、車両を構成するファイルが入っています。
-    │
-    └ GeneralAtsPlugin      &lt;== GeneralAtsPluginパック (通称: GAP)　が入っています。
+├── Rock_On    &lt;== Rock_On 制作のアドオンは、ここに入ります。
+│   └── Train  &lt;== 車両アドオンは、ここに入ります。
+│       └── JR &lt;== JR会社および国鉄に所属の車両は、ここに入ります。
+│           ├── Formation   &lt;== 各車両区ごとのフォルダの中に、 Vehicle.txt 相当のファイルが入っています。
+│           ├── Plugin      &lt;== Atsプラグインが入っています。
+│           └── Vehicle     &lt;== 車両形式ごとに、車両を構成するファイルが入っています。
+│
+└ GeneralAtsPlugin      &lt;== GeneralAtsPluginパック (通称: GAP)　が入っています。
 </code></pre><ul>
 <li>インストールする際は、 <code>Scenarios</code> フォルダへそのまま入れて頂ければOKです。</li>
 </ul>


### PR DESCRIPTION
突然のプルリクを失礼いたします。

下記ページの「フォルダの構成」について、[2019/08/18安定版](https://github.com/mikangogo/JRTrainPack/releases/tag/Stable)では `Scenarios` 直下に `GeneralAtsPlugin` が置かれているため、そちらに合うように修正しました。
https://mikangogo.github.io/posts/jrtrainpack/

もしご都合と合わない点がありましたらお手数ですがリジェクト等いただければと思います。